### PR TITLE
Integrated pagination api

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,6 @@ $ npm run start
 
 - Paths that are already setup
     -  `/`: The home page
-    - `/dog`: The page for dog info
+    - `/dogs`: The page for dog info
     - `/profile`: The page for user profile
     - `/quiz`: The page for quiz

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "@testing-library/react": "^13.4.0",
     "@testing-library/user-event": "^13.5.0",
     "dotenv": "^16.0.3",
+    "query-string": "^7.1.1",
     "react": "^18.2.0",
     "react-audio-player": "^0.17.0",
     "react-dom": "^18.2.0",

--- a/src/Components/DogCard.js
+++ b/src/Components/DogCard.js
@@ -6,42 +6,38 @@ import CardHeader from "@mui/material/CardHeader";
 import CardMedia from "@mui/material/CardMedia";
 import DogInfo from "./DogInfo";
 import ReactAudioPlayer from "react-audio-player";
+import commonConstants from "../constants/commonConstants";
 import dogPageStyle from "../css/dogPageStyle";
 import isValidHttpUrl from "../utils/isValidHttpUrl";
 
 export default function DogCard({ dog }) {
-  if (isValidHttpUrl(dog.image_url)) {
-    return (
-      <Card sx={dogPageStyle.dogCardStyle.dogCard}>
-        <CardMedia
-          component="img"
-          image={dog.image_url}
-          alt="img/doge.png"
-          sx={dogPageStyle.dogCardStyle.dogCardMedia}
+  return (
+    <Card sx={dogPageStyle.dogCardStyle.dogCard}>
+      <CardMedia
+        component="img"
+        image={isValidHttpUrl(dog.image_url) ? dog.image_url : commonConstants.dogeImageSrc}
+        sx={dogPageStyle.dogCardStyle.dogCardMedia}
+      />
+
+      <CardContent sx={dogPageStyle.dogCardStyle.dogCardContent}>
+        <CardHeader
+          titleTypographyProps={dogPageStyle.dogCardStyle.dogCardHeaderTitle}
+          title={dog.name}
         />
-
-        <CardContent sx={dogPageStyle.dogCardStyle.dogCardContent}>
-          <CardHeader
-            titleTypographyProps={dogPageStyle.dogCardStyle.dogCardHeaderTitle}
-            title={dog.name}
+        {isValidHttpUrl(dog.pronunciation_url) && (
+          <ReactAudioPlayer
+            src={dog.pronunciation_url}
+            controls
+            style={{ marginLeft: "14px" }}
           />
-          {isValidHttpUrl(dog.pronunciation_url) && (
-            <ReactAudioPlayer
-              src={dog.pronunciation_url}
-              controls
-              style={{ marginLeft: "14px" }}
-            />
-          )}
+        )}
 
-          <DogInfo
-            categories={dog.categories}
-            origins={dog.origins}
-            size={dog.size}
-          />
-        </CardContent>
-      </Card>
-    );
-  } else {
-    return <div></div>
-  }
+        <DogInfo
+          categories={dog.categories}
+          origins={dog.origins}
+          size={dog.size}
+        />
+      </CardContent>
+    </Card>
+  );
 }

--- a/src/Components/DogInfoMultiChipsStack.js
+++ b/src/Components/DogInfoMultiChipsStack.js
@@ -6,7 +6,7 @@ import Stack from "@mui/material/Stack";
 export default function DogInfoMultiChipsStack ({items}) {
     return (
         <Stack justifyContent="space-between" flexDirection={"row-reverse"} width="50%" flexWrap="wrap" textAlign="right" >
-          {items && items.map((item) => <Chip label={item.name} />)}
+          {items && items.map((item) => <Chip key={item.id} label={item.name} />)}
         </Stack>
     )
 }

--- a/src/Components/DogPagination.js
+++ b/src/Components/DogPagination.js
@@ -1,0 +1,50 @@
+import * as React from "react";
+
+import { ThemeProvider, createTheme } from "@mui/material/styles";
+
+import ArrowCircleLeftIcon from "@mui/icons-material/ArrowCircleLeft";
+import ArrowCircleRightIcon from "@mui/icons-material/ArrowCircleRight";
+import Box from "@mui/material/Box";
+import Button from "@mui/material/Button";
+import Fab from "@mui/material/Fab";
+
+const theme = createTheme({
+  palette: {
+    primary: {
+      main: "#bbdefb",
+    },
+  },
+});
+
+export default function DogPagination({
+  handleClickPrev,
+  handleClickNext,
+  disablePrev,
+  disableNext,
+}) {
+  return (
+    <ThemeProvider theme={theme}>
+      <Box
+        sx={{
+          "& > :not(style)": { m: 1 },
+          position: "fixed",
+          bottom: 16,
+          right: 16,
+        }}
+      >
+        <Button onClick={handleClickPrev} disabled={disablePrev}>
+          <Fab variant="extended" color="primary">
+            <ArrowCircleLeftIcon sx={{ mr: 1 }} />
+            Previous
+          </Fab>
+        </Button>
+        <Button onClick={handleClickNext} disabled={disableNext}>
+          <Fab variant="extended" color="primary">
+            <ArrowCircleRightIcon sx={{ mr: 1 }} />
+            Next
+          </Fab>
+        </Button>
+      </Box>
+    </ThemeProvider>
+  );
+}

--- a/src/Components/DogPagination.js
+++ b/src/Components/DogPagination.js
@@ -5,7 +5,6 @@ import { ThemeProvider, createTheme } from "@mui/material/styles";
 import ArrowCircleLeftIcon from "@mui/icons-material/ArrowCircleLeft";
 import ArrowCircleRightIcon from "@mui/icons-material/ArrowCircleRight";
 import Box from "@mui/material/Box";
-import Button from "@mui/material/Button";
 import Fab from "@mui/material/Fab";
 
 const theme = createTheme({
@@ -32,18 +31,15 @@ export default function DogPagination({
           right: 16,
         }}
       >
-        <Button onClick={handleClickPrev} disabled={disablePrev}>
-          <Fab variant="extended" color="primary">
-            <ArrowCircleLeftIcon sx={{ mr: 1 }} />
-            Previous
-          </Fab>
-        </Button>
-        <Button onClick={handleClickNext} disabled={disableNext}>
-          <Fab variant="extended" color="primary">
-            <ArrowCircleRightIcon sx={{ mr: 1 }} />
-            Next
-          </Fab>
-        </Button>
+        <Fab variant="extended" color="primary" onClick={handleClickPrev}>
+          <ArrowCircleLeftIcon sx={{ mr: 1 }} />
+          Previous
+        </Fab>
+
+        <Fab variant="extended" color="primary" onClick={handleClickNext}>
+          <ArrowCircleRightIcon sx={{ mr: 1 }} />
+          Next
+        </Fab>
       </Box>
     </ThemeProvider>
   );

--- a/src/Components/Navbar.js
+++ b/src/Components/Navbar.js
@@ -54,7 +54,7 @@ function Navbar() {
             </Typography>
             <Box sx={navbarStyle.tabBox}>
               <Tabs value={value} onChange={handleChange}>
-                <Tab label="Doggo" to={commonConstants.dogRoute} component={Link} />
+                <Tab label="Doggo" to={commonConstants.dogRoute} component={Link} onClick={() => window.location.reload()} />
                 <Tab label="Quiz" to={commonConstants.quizRoute} component={Link} />
               </Tabs>
             </Box>

--- a/src/Components/Navbar.js
+++ b/src/Components/Navbar.js
@@ -26,7 +26,7 @@ const darkTheme = createTheme({
 });
 
 function Navbar() {
-  const [value, setValue] = React.useState("1");
+  const [value, setValue] = React.useState(1);
 
   const handleChange = (event, newValue) => {
     setValue(newValue);

--- a/src/Components/Navbar.js
+++ b/src/Components/Navbar.js
@@ -54,7 +54,7 @@ function Navbar() {
             </Typography>
             <Box sx={navbarStyle.tabBox}>
               <Tabs value={value} onChange={handleChange}>
-                <Tab label="Doggo" to={commonConstants.dogRoute} component={Link} onClick={() => window.location.reload()} />
+                <Tab label="Doggo" to={commonConstants.dogRoute} component={Link} />
                 <Tab label="Quiz" to={commonConstants.quizRoute} component={Link} />
               </Tabs>
             </Box>

--- a/src/Components/Navbar.js
+++ b/src/Components/Navbar.js
@@ -1,7 +1,6 @@
 import "../css/common.css";
 
-import * as React from "react";
-
+import {React, useState} from "react";
 import { ThemeProvider, createTheme } from "@mui/material/styles";
 
 import AccountCircle from "@mui/icons-material/AccountCircle";
@@ -18,6 +17,7 @@ import Toolbar from "@mui/material/Toolbar";
 import Typography from "@mui/material/Typography";
 import commonConstants from "../constants/commonConstants";
 import navbarStyle from "../css/navbarStyle";
+import { useLocation } from 'react-router-dom';
 
 const darkTheme = createTheme({
   palette: {
@@ -26,11 +26,26 @@ const darkTheme = createTheme({
 });
 
 function Navbar() {
-  const [value, setValue] = React.useState(1);
-
-  const handleChange = (event, newValue) => {
-    setValue(newValue);
+  
+  let location = useLocation();
+  const currentTab = () => {
+    let path = location.pathname;
+    if (path === commonConstants.dogRoute) return 0;
+    else if (path === commonConstants.quizRoute) return 1;
+    else return 2;
   };
+  const [value, setValue] = useState(currentTab);
+  const handleClickDoggo = (event, newValue) => {
+    setValue(currentTab);
+    window.location.href = commonConstants.dogRoute;
+  }
+
+  const handleClickQuiz = (event, newValule) => {
+    setValue(currentTab);
+    window.location.href = commonConstants.quizRoute;
+  }
+
+    
 
   return (
     <ThemeProvider theme={darkTheme}>
@@ -53,9 +68,9 @@ function Navbar() {
               LeetDoge
             </Typography>
             <Box sx={navbarStyle.tabBox}>
-              <Tabs value={value} onChange={handleChange}>
-                <Tab label="Doggo" to={commonConstants.dogRoute} component={Link} />
-                <Tab label="Quiz" to={commonConstants.quizRoute} component={Link} />
+              <Tabs value={value} >
+                <Tab label="Doggo" to={commonConstants.dogRoute} component={Link} onClick={handleClickDoggo} />
+                <Tab label="Quiz" to={commonConstants.quizRoute} component={Link} onClick={handleClickQuiz} />
               </Tabs>
             </Box>
             <IconButton sx={navbarStyle.profileButton}>

--- a/src/Pages/DogPage.js
+++ b/src/Pages/DogPage.js
@@ -4,6 +4,7 @@ import Container from "@mui/material/Container";
 import DogCard from "../Components/DogCard";
 import DogPagination from "../Components/DogPagination";
 import apiRoutes from "../constants/apiRoutes";
+import commonConstants from "../constants/commonConstants";
 import commonStyle from "../css/commonStyle";
 import dogConstants from "../constants/dogConstants";
 import { httpCall } from "../utils/httpCall";
@@ -20,10 +21,10 @@ function DogPage() {
   const getDogs = async () => {
     const response = await httpCall(apiRoutes.getAllDogs, "GET", null, null);
     setDogs(response.data);
-    setPrevLink(response.links.prev.href);
-    setNextLink(response.links.next.href);
-
-    const cOffset = getOffset(response.links.curr.href);
+    setPrevLink(getLink(response.links, commonConstants.linkTypePrev));
+    setNextLink(getLink(response.links, commonConstants.linkTypeNext));
+    
+    const cOffset = getOffset(getLink(response.links, commonConstants.linkTypeCurr));
     if (cOffset == 0) {
       setDisablePrev(true);
     } else {
@@ -40,10 +41,10 @@ function DogPage() {
   const handleClickPrev = async () => {
     const response = await httpCall(prevLink, "GET", null, null);
     setDogs(response.data);
-    setPrevLink(response.links.prev.href);
-    setNextLink(response.links.next.href);
-
-    const cOffset = getOffset(response.links.curr.href);
+    setPrevLink(getLink(response.links, commonConstants.linkTypePrev));
+    setNextLink(getLink(response.links, commonConstants.linkTypeNext));
+    
+    const cOffset = getOffset(getLink(response.links, commonConstants.linkTypeCurr));
     if (cOffset == 0) {
       setDisablePrev(true);
     } else {
@@ -60,11 +61,10 @@ function DogPage() {
   const handleClickNext = async () => {
     const response = await httpCall(nextLink, "GET", null, null);
     setDogs(response.data);
-    setPrevLink(response.links.prev.href);
-    setNextLink(response.links.next.href);
+    setPrevLink(getLink(response.links, commonConstants.linkTypePrev));
+    setNextLink(getLink(response.links, commonConstants.linkTypeNext));
     
-    const cOffset = getOffset(response.links.curr.href);
-    
+    const cOffset = getOffset(getLink(response.links, commonConstants.linkTypeCurr));
     if (cOffset == 0) {
       setDisablePrev(true);
     } else {
@@ -84,6 +84,9 @@ function DogPage() {
     return parsed.offset ? parsed.offset : 0;
   };
 
+  const getLink = (linkArray, linkType) => {
+    return linkArray.find(item => item.rel == linkType).href;
+  }
   useEffect(() => {
     getDogs();
   }, []);

--- a/src/Pages/DogPage.js
+++ b/src/Pages/DogPage.js
@@ -89,7 +89,7 @@ function DogPage() {
   }, []);
   return (
     <Container maxWidth={false} sx={commonStyle.pageContainerStyle}>
-      {dogs && dogs.map((dog) => <DogCard dog={dog} />)}
+      {dogs && dogs.map((dog) => <DogCard key={dog.id} dog={dog}/>)}
       <Container>
         <DogPagination
           handleClickPrev={handleClickPrev}

--- a/src/Pages/DogPage.js
+++ b/src/Pages/DogPage.js
@@ -2,29 +2,102 @@ import React, { useEffect, useState } from "react";
 
 import Container from "@mui/material/Container";
 import DogCard from "../Components/DogCard";
+import DogPagination from "../Components/DogPagination";
 import apiRoutes from "../constants/apiRoutes";
 import commonStyle from "../css/commonStyle";
+import dogConstants from "../constants/dogConstants";
 import { httpCall } from "../utils/httpCall";
+
+const queryString = require("query-string");
 
 function DogPage() {
   const [dogs, setDogs] = useState([]);
+  const [prevLink, setPrevLink] = useState(null);
+  const [nextLink, setNextLink] = useState(null);
+  const [disableNext, setDisableNext] = useState(false);
+  const [disablePrev, setDisablePrev] = useState(false);
+
   const getDogs = async () => {
-    let response = await httpCall(
-      apiRoutes.getAllDogs,
-      "GET",
-      null,
-      null
-    );
-    setDogs(response);
+    const response = await httpCall(apiRoutes.getAllDogs, "GET", null, null);
+    setDogs(response.data);
+    setPrevLink(response.links.prev.href);
+    setNextLink(response.links.next.href);
+
+    const cOffset = getOffset(response.links.curr.href);
+    if (cOffset == 0) {
+      setDisablePrev(true);
+    } else {
+      setDisablePrev(false);
+    }
+
+    if (response.data.length < dogConstants.defaultPageSize) {
+      setDisableNext(true);
+    } else {
+      setDisableNext(false);
+    }
+  };
+
+  const handleClickPrev = async () => {
+    const response = await httpCall(prevLink, "GET", null, null);
+    setDogs(response.data);
+    setPrevLink(response.links.prev.href);
+    setNextLink(response.links.next.href);
+
+    const cOffset = getOffset(response.links.curr.href);
+    if (cOffset == 0) {
+      setDisablePrev(true);
+    } else {
+      setDisablePrev(false);
+    }
+
+    if (response.data.length < dogConstants.defaultPageSize) {
+      setDisableNext(true);
+    } else {
+      setDisableNext(false);
+    }
+  };
+
+  const handleClickNext = async () => {
+    const response = await httpCall(nextLink, "GET", null, null);
+    setDogs(response.data);
+    setPrevLink(response.links.prev.href);
+    setNextLink(response.links.next.href);
+    
+    const cOffset = getOffset(response.links.curr.href);
+    
+    if (cOffset == 0) {
+      setDisablePrev(true);
+    } else {
+      setDisablePrev(false);
+    }
+
+    if (response.data.length < dogConstants.defaultPageSize) {
+      setDisableNext(true);
+    } else {
+      setDisableNext(false);
+    }
+  };
+
+  const getOffset = (hrefLink) => {
+    let qs = hrefLink.substring(hrefLink.indexOf("?") + 1);
+    let parsed = queryString.parse(qs);
+    return parsed.offset ? parsed.offset : 0;
   };
 
   useEffect(() => {
-    console.log(`${process.env.REACT_APP_DOGINFO_API_HOST}`)
     getDogs();
   }, []);
   return (
     <Container maxWidth={false} sx={commonStyle.pageContainerStyle}>
       {dogs && dogs.map((dog) => <DogCard dog={dog} />)}
+      <Container>
+        <DogPagination
+          handleClickPrev={handleClickPrev}
+          handleClickNext={handleClickNext}
+          disablePrev={disablePrev}
+          disableNext={disableNext}
+        />
+      </Container>
     </Container>
   );
 }

--- a/src/constants/commonConstants.js
+++ b/src/constants/commonConstants.js
@@ -4,12 +4,20 @@ const profileRoute = "/profile";
 const quizRoute = "/quiz";
 const rootRoute = "/";
 
+// Pagination links, rel property
+const linkTypeCurr = "current";
+const linkTypePrev = "prev";
+const linkTypeNext = "next";
+
 const commonConstants = {
   dogRoute,
   profileRoute,
   quizRoute,
   dogeImageSrc,
-  rootRoute
+  rootRoute,
+  linkTypePrev,
+  linkTypeNext,
+  linkTypeCurr
 };
 
 export default commonConstants;

--- a/src/constants/commonConstants.js
+++ b/src/constants/commonConstants.js
@@ -1,5 +1,5 @@
 const dogeImageSrc = "img/doge.png";
-const dogRoute = "/dog";
+const dogRoute = "/dogs";
 const profileRoute = "/profile";
 const quizRoute = "/quiz";
 const rootRoute = "/";

--- a/src/constants/dogConstants.js
+++ b/src/constants/dogConstants.js
@@ -1,11 +1,15 @@
 const categoryTitle = "Category";
 const originTitle = "Origin";
 const sizeTitle = "Size";
+const defaultPageSize = 9;
+const defaultOffset = 0;
 
 const dogConstants ={
     categoryTitle,
     originTitle,
-    sizeTitle
+    sizeTitle,
+    defaultPageSize,
+    defaultOffset
 }
 
 export default dogConstants;


### PR DESCRIPTION
New feature:
1. Paginated dogs (showing 9 dogs per page)
2. Previous and Next buttons
3. Goes to the first page when the Doggo tab on the navbar is clicked

- How to test it: 
Please test the front end with the code from this pull request for the backend https://github.com/COMSE6156-unnamed/dog-info/pull/24

    - How to run the backend: 
    ```
    $ npm start
    ```
 
    - How to run the frontend
        - Put this .env file in the root directory of the doggo-frontend repo
        ```
       REACT_APP_DOGINFO_API_HOST=http://localhost:3000
       PORT=8080
        ```
        - Run the following command
        ```
       $ npm run start
        ```

       - Test the frontend by going to: `http://localhost:8080/dogs`

